### PR TITLE
Search for users by slug instead of name

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,7 +33,7 @@ class App extends Component {
       userid: null,
     }));
     const resp = await fetch(
-      `https://kitsu.io/api/edge/users?filter[name]=${name}`
+      `https://kitsu.io/api/edge/users?filter[slug]=${name}`
     );
     if (resp.ok) {
       const { data } = await resp.json();


### PR DESCRIPTION
Kitsu added a Display Name feature shortly after this was made which made the `name` property non-unique. `slug` provides the same functionality as before this feature was added.